### PR TITLE
list-all: fetch versions from semver.io

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,32 +1,4 @@
 #!/usr/bin/env bash
 
-versions_list=(
-  5.5.0
-  5.4.1
-  5.4.0
-  5.3.0
-  5.2.0
-  5.1.1
-  5.1.0
-  5.0.0
-  4.2.3
-  4.2.2
-  4.2.1
-  4.2.0
-  4.1.2
-  4.1.1
-  4.1.0
-  4.0.0
-  0.12.7
-  0.12.3
-  0.12.2
-)
-
-versions=""
-
-for version in "${versions_list[@]}"
-do
-  versions="${versions} ${version}"
-done
-
-echo $versions
+echo $(curl --silent http://semver.io/node/versions \
+  | grep -E -v '^0\.([0-9]|10|11)\.')


### PR DESCRIPTION
This makes `asdf list-all nodejs` also display an up-to-date list of node versions 0.12 and above.

![image](https://cloud.githubusercontent.com/assets/74385/13037559/9dc9b744-d3be-11e5-93ec-fb6e2a434732.png)
