### PR TITLE
Fix `asdf_nodejs_plugin_path`

### DIFF
--- a/npm-hooks/postinstall
+++ b/npm-hooks/postinstall
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 asdf_nodejs_installs_path=$(dirname $(dirname $(dirname $NODE)))
-asdf_nodejs_plugin_path=${asdf_nodejs_installs_path/installs/plugins}
+asdf_nodejs_plugin_path=${asdf_nodejs_installs_path}/installs/plugins
 bash $asdf_nodejs_plugin_path/bin/postinstall


### PR DESCRIPTION
When installing a module that uses `postinstall` it threw an error

> No such plugin.

The variable `asdf_nodejs_plugin_path` was assigned wrong.